### PR TITLE
Fungus Positive Abilities

### DIFF
--- a/Custom Origins/data/custom/origins/fungus.json
+++ b/Custom Origins/data/custom/origins/fungus.json
@@ -5,7 +5,10 @@
     "impact": 2,
     "icon": "promenade:white_mushroom",
     "powers": [
-        "custom:fungus_size"
+        "custom:fungus_size",
+        "custom:fungus_poison",
+        "custom:fungus_resistance",
+        "custom:fungus_spores"
     ],
     "loading_priority": 100
 }

--- a/Custom Origins/data/custom/origins/fungus.json
+++ b/Custom Origins/data/custom/origins/fungus.json
@@ -8,7 +8,8 @@
         "custom:fungus_size",
         "custom:fungus_poison",
         "custom:fungus_resistance",
-        "custom:fungus_spores"
+        "custom:fungus_spores",
+        "custom:weakness"
     ],
     "loading_priority": 100
 }

--- a/Custom Origins/data/custom/powers/fungus_poison.json
+++ b/Custom Origins/data/custom/powers/fungus_poison.json
@@ -1,0 +1,14 @@
+{
+    "type": "origins:attacker_action_when_hit",
+    "name": "Death Cap",
+    "description": "When you're hit by an attacker, a cloud of spores attacks them.",
+    "entity_action": {
+        "type": "origins:apply_effect",
+        "effect": {
+            "effect": "minecraft:wither",
+            "duration": 100,
+            "amplifier": 0
+        }
+    },
+    "cooldown": 200
+}

--- a/Custom Origins/data/custom/powers/fungus_resistance.json
+++ b/Custom Origins/data/custom/powers/fungus_resistance.json
@@ -1,0 +1,10 @@
+{
+    "type": "origins:effect_immunity",
+    "name": "Fungal Resistance",
+    "description": "You take no damage from effects that would normally harm you due to your toxic nature.",
+    "effects": [
+        "minecraft:instant_damage",
+        "minecraft:wither",
+        "minecraft:poison"
+    ]
+}

--- a/Custom Origins/data/custom/powers/fungus_size.json
+++ b/Custom Origins/data/custom/powers/fungus_size.json
@@ -4,20 +4,20 @@
     "description": "Due to your rather miniscule origins, you lack a bit in the height department.",
     "scale": {
         "type": "extraorigins:modify_size",
-        "scale": 0.7
+        "scale": 0.5
     },
     "motion": {
         "type": "extraorigins:modify_size",
         "scale_types": [
             "pehkui:motion"
         ],
-        "scale": 0.9
+        "scale": 0.8
     },
     "health": {
         "type": "extraorigins:modify_size",
         "scale_types": [
             "pehkui:health"
         ],
-        "scale": 0.6
+        "scale": 0.5
     }
 }

--- a/Custom Origins/data/custom/powers/fungus_spores.json
+++ b/Custom Origins/data/custom/powers/fungus_spores.json
@@ -1,0 +1,20 @@
+{
+    "type": "origins:self_action_on_hit",
+    "name": "Fungal Spores",
+    "description": "Upon your death you release a cloud of toxic spores, injuring any unlucky fellow that was close enough.",
+    "entity_action": {
+        "type": "origins:spawn_effect_cloud",
+        "radius": 5,
+        "wait_time": 0,
+        "effect": {
+            "effect": "minecraft:poison",
+            "amplifier": 1,
+            "duration": 200
+        }
+    },
+    "condition": {
+        "type": "origins:health",
+        "comparison": "<",
+        "compare_to": 1
+    }
+}

--- a/Custom Origins/data/custom/powers/weakness.json
+++ b/Custom Origins/data/custom/powers/weakness.json
@@ -1,0 +1,9 @@
+{
+    "type": "origins:modify_break_speed",
+    "name": "Weakness",
+    "description": "You are weaker than usual and break blocks at a slower rate.",
+    "modifier": {
+        "operation": "multiply_base",
+        "value": -0.8
+    }
+}


### PR DESCRIPTION
Added abilities that can poison others once damaged, can poison those nearby upon death, and make the fungus resistant to effects that would normally damage the player.